### PR TITLE
Raise at next Checkpoint if Non-awaited coroutine found.

### DIFF
--- a/trio/_core/_exceptions.py
+++ b/trio/_core/_exceptions.py
@@ -32,6 +32,14 @@ class RunFinishedError(RuntimeError):
 
 RunFinishedError.__module__ = "trio"
 
+class NonAwaitedCoroutine(RuntimeError):
+    """Raised by blocking calls if a non-awaited coroutine detected in current task
+    """
+    pass
+
+NonAwaitedCoroutine.__module__ = "trio"
+
+
 
 class WouldBlock(Exception):
     """Raised by ``X_nowait`` functions if ``X`` would block.


### PR DESCRIPTION
right now that works only if the task is not finisehd. Not sure what to
do if the task is done as you have no occasions to throw in it. Should
we still return the `final_result` as a Result , or make it an `Error()`
?

Debugging is still a bit weird as you need to find the checkpoint in the
middle of the stacktrace (I guess we can improve that). Othe question
would be is there a way to get the previous checkpoint of the current
task to narrow tings down.

It's still hard to debug when the non-awaited coroutine is not at the
same stacklevel than the schedule point. We may be able to do better by
inspecting unawaited coro frames maybe ?

The await_later and context managers to relax/enforce await are not
exposed, and I'm unsure whether we want to have custom CoroProtectors
(likely yes for testing). We may also want to list all the unawaited
coroutines in the error message, and so far I have not tried with many
tasks, but the internals of Trio are still unfamiliar.

Docs and Tests are still missing.